### PR TITLE
Potential fix for code scanning alert no. 25: Dependency download using unencrypted communication channel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem "rails", "~> 7.2.0"
 


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/25](https://github.com/Wbaker7702/nemo/security/code-scanning/25)

To fix the issue, the protocol in the source URL should be changed from `http` to `https`. This ensures that all communication with the RubyGems repository is encrypted and secure. The change is straightforward and does not affect the functionality of the code. Specifically, the `source` line in the `Gemfile` should be updated to use `https://rubygems.org`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
