### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@babel/plugin-transform-runtime": "7.18.10",
     "@babel/preset-env": "7.26.0",
     "@babel/preset-react": "7.25.9",
-
     "@rails/webpacker": "5.4.3",
     "@sentry/react": "6.19.7",
     "@sentry/tracing": "6.19.7",
@@ -68,7 +67,8 @@
     "regenerator-runtime": "0.14.0",
     "style-loader": "1.2.1",
     "webpack": "5.97.0",
-    "webpack-cli": "4.10.0"
+    "webpack-cli": "4.10.0",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@babel/eslint-parser": "7.18.9",

--- a/vendor/assets/javascripts/trumbowyg/trumbowyg.js
+++ b/vendor/assets/javascripts/trumbowyg/trumbowyg.js
@@ -9,6 +9,7 @@
  *         Website : alex-d.fr
  */
 
+import DOMPurify from 'dompurify'; // Import DOMPurify for sanitization
 jQuery.trumbowyg = {
     langs: {
         en: {
@@ -511,6 +512,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             t.isTextarea = t.$ta.is('textarea');
             if (t.isTextarea) {
                 html = t.$ta.val();
+                html = DOMPurify.sanitize(html); // Sanitize the input to prevent XSS
                 t.$ed = $('<div/>');
                 t.$box
                     .insertAfter(t.$ta)


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/13](https://github.com/Wbaker7702/nemo/security/code-scanning/13)

To fix the issue, the `html` variable should be sanitized or escaped before being used in `t.$ed.html(html)`. This ensures that any potentially malicious input is neutralized and cannot be interpreted as executable HTML or JavaScript.

The best approach is to use a library like `DOMPurify` to sanitize the input, as it provides robust protection against XSS by removing dangerous elements and attributes from the HTML string. Alternatively, if the input is meant to be plain text, it can be escaped using a function like `_.escape` from Lodash or a custom escaping function.

Changes to make:
1. Import or define a sanitization/escaping function.
2. Apply the sanitization/escaping function to the `html` variable before passing it to `t.$ed.html(html)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced security by sanitizing HTML content when initializing the editor, helping to prevent unsafe content from being loaded.

* **Chores**
  * Added a new dependency to improve content sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->