### PR TITLE
Potential fix for code scanning alert no. 2: Useless regular-expression character escape

### DIFF
--- a/vendor/assets/javascripts/trumbowyg/trumbowyg.js
+++ b/vendor/assets/javascripts/trumbowyg/trumbowyg.js
@@ -232,7 +232,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                 var scriptElements = document.getElementsByTagName('script');
                 for (var i = 0; i < scriptElements.length; i += 1) {
                     var source = scriptElements[i].src;
-                    var matches = source.match('trumbowyg(\.min)?\.js');
+                    var matches = source.match('trumbowyg(.min)?.js');
                     if (matches != null) {
                         svgPathOption = source.substring(0, source.indexOf(matches[0])) + 'ui/icons.svg';
                     }


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/2](https://github.com/Wbaker7702/nemo/security/code-scanning/2)

To fix the issue, we need to remove the unnecessary backslash in the escape sequence `\.` on line 235. The corrected regular expression should use `.` instead of `\.`. This change ensures that the code is cleaner and avoids confusion while maintaining the same functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the Trumbowyg script file, ensuring more reliable loading of SVG icons in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->