### PR TITLE
Potential fix for code scanning alert no. 23: Incomplete regular expression for hostnames

### DIFF
--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -61,7 +61,7 @@ describe Notifier do
       expect(mail.to).to eq([user.email])
       expect(mail.subject).to eq("Password Reset Instructions")
       expect(mail.body).to match(/A request to reset your NEMO password has been made/)
-      expect(mail.body).to match("http://www.example.com/en/password-resets")
+      expect(mail.body).to match(/http:\/\/www\.example\.com\/en\/password-resets/)
     end
   end
 


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/23](https://github.com/Wbaker7702/nemo/security/code-scanning/23)

To fix the problem, update the regular expression in the test on line 64 to escape the `.` in `example.com`. This means changing the line from `expect(mail.body).to match("http://www.example.com/en/password-resets")` to `expect(mail.body).to match(/http:\/\/www\.example\.com\/en\/password-resets/)`. This change ensures that the test only matches the exact URL and does not allow for unintended matches due to the unescaped `.`. The change should be made in the file `spec/mailers/notifier_spec.rb`, specifically on line 64. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
