### PR TITLE
Potential fix for code scanning alert no. 19: CSRF protection weakened or disabled

### DIFF
--- a/app/controllers/sms_controller.rb
+++ b/app/controllers/sms_controller.rb
@@ -15,7 +15,6 @@ class SmsController < ApplicationController
   skip_authorization_check only: :create
 
   # disable csrf protection for this stuff
-  protect_from_forgery except: :create
 
   helper_method :smses
 


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/19](https://github.com/Wbaker7702/nemo/security/code-scanning/19)

To fix the problem, we should remove the line that disables CSRF protection for the `create` action (`protect_from_forgery except: :create`). This will re-enable Rails' default CSRF protection for all actions, including `create`. If the `create` action is intended to be called by external services (such as SMS gateways) that cannot provide a CSRF token, then a better approach is to move this action to a dedicated API controller that uses token-based authentication and explicitly skips CSRF protection, with clear documentation and separation from browser-based controllers. For now, the best fix within the shown code is to simply remove the line that disables CSRF protection.

**Steps:**
- Remove the line `protect_from_forgery except: :create` from `app/controllers/sms_controller.rb`.
- No additional imports or method changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
