### PR TITLE
Potential fix for code scanning alert no. 22: Incomplete regular expression for hostnames

### DIFF
--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -20,7 +20,7 @@ describe Notifier do
         expect(mail.subject).to eq("Welcome to NEMO!")
         expect(mail.body.encoded).to match("Welcome to NEMO!")
         expect(mail.body.encoded).to match("Your login name is")
-        expect(mail.body.encoded).to match("http://www.example.com/en/password-resets/")
+        expect(mail.body.encoded).to match("http://www\.example\.com/en/password-resets/")
       end
     end
 


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/22](https://github.com/Wbaker7702/nemo/security/code-scanning/22)

To fix the problem, we should escape the `.` characters in the string `"http://www.example.com/en/password-resets/"` so that the regular expression matches the literal dots, not any character. This can be done by replacing each `.` with `\.` in the string. In Ruby, to represent a literal backslash in a double-quoted string, we need to use two backslashes (`\\.`). Alternatively, we can use a raw string (with `%r{}`) or single quotes, but since the current code uses double quotes, we should escape accordingly. The change should be made on line 23 of `spec/mailers/notifier_spec.rb`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
