### PR TITLE
Potential fix for code scanning alert no. 15: DOM text reinterpreted as HTML

### DIFF
--- a/vendor/assets/javascripts/trumbowyg/trumbowyg.js
+++ b/vendor/assets/javascripts/trumbowyg/trumbowyg.js
@@ -1090,12 +1090,10 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             if (!force && t.$ed.is(':visible')) {
                 t.syncTextarea();
             } else {
-                // wrap the content in a div it's easier to get the innerhtml
-                var html = $('<div>').html(t.$ta.val());
-                //scrub the html before loading into the doc
-                var safe = $('<div>').append(html);
-                $(t.o.tagsToRemove.join(','), safe).remove();
-                t.$ed.html(safe.contents().html());
+                // Sanitize the HTML from the textarea before loading into the editor
+                var rawHtml = t.$ta.val();
+                var sanitizedHtml = DOMPurify.sanitize(rawHtml);
+                t.$ed.html(sanitizedHtml);
             }
 
             if (t.o.autogrow) {


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/15](https://github.com/Wbaker7702/nemo/security/code-scanning/15)

To fix the problem, we should sanitize the HTML content extracted from the textarea before inserting it into the DOM as HTML. The best way to do this is to use the imported DOMPurify library to clean the HTML string before setting it as the content of the editor. Specifically, in the `syncCode` function, after extracting the HTML from the textarea (`t.$ta.val()`), we should pass it through `DOMPurify.sanitize()` before using it to set the editor's HTML. This change should be made in the block starting at line 1094, replacing the current logic with a call to DOMPurify.

No new methods or imports are needed, as DOMPurify is already imported at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
