### PR TITLE
Potential fix for code scanning alert no. 21: Overly permissive regular expression range

### DIFF
--- a/app/models/odk/dynamic_pattern_parser.rb
+++ b/app/models/odk/dynamic_pattern_parser.rb
@@ -4,7 +4,7 @@ module ODK
   # Abstract parent class for classes that parse $-style patterns for ODK.
   class DynamicPatternParser
     # Basic regex for codes like $Question7 or $Question3:value with non-capturing group (?:)
-    CODE_REGEX = /[$]!?[A-z]\w*(?::value)?/.freeze
+    CODE_REGEX = /[$]!?[A-Za-z]\w*(?::value)?/.freeze
 
     # Same as above but anchored to string start and end for checking individual tokens.
     ANCHORED_CODE_REGEX = Regexp.new("\\A#{CODE_REGEX.source}\\z")


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/21](https://github.com/Wbaker7702/nemo/security/code-scanning/21)

To fix the problem, we need to update the regular expression on line 7 to use `[A-Za-z]` instead of `[A-z]`. This change ensures that only uppercase and lowercase English letters are matched, and none of the unintended ASCII characters between `Z` and `a` are included. The change should be made in all places where the original `CODE_REGEX` is used, but since the other regexes reference `CODE_REGEX.source`, updating the definition of `CODE_REGEX` is sufficient. No additional imports or method definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
