### PR TITLE
Potential fix for code scanning alert no. 14: DOM text reinterpreted as HTML

### DIFF
--- a/vendor/assets/javascripts/trumbowyg/trumbowyg.js
+++ b/vendor/assets/javascripts/trumbowyg/trumbowyg.js
@@ -982,7 +982,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                         .removeClass(prefix + 'editor')
                         .removeAttr('contenteditable')
                         .removeAttr('dir')
-                        .html(t.html())
+                        .html(DOMPurify.sanitize(t.html()))
                         .show()
                 );
             }


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/14](https://github.com/Wbaker7702/nemo/security/code-scanning/14)

To fix the problem, we need to ensure that any content taken from the textarea (`t.$ta.val()`) and inserted into the DOM as HTML is properly sanitized to remove any potentially dangerous code (such as `<script>` tags or event handlers). The best way to do this is to use a well-known library like DOMPurify to sanitize the HTML before inserting it. In this case, we should sanitize the value returned by `t.html()` before passing it to `.html()` on line 985. Since DOMPurify is already imported at the top of the file, we can use it directly.

Specifically, in the block:
```js
985: .html(t.html())
```
We should change it to:
```js
985: .html(DOMPurify.sanitize(t.html()))
```
This ensures that any HTML inserted into the DOM is first sanitized.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
