### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,8 @@ on: [push]
 jobs:
   tests:
     name: Tests
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     env:
       RAILS_ENV: test


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/26](https://github.com/Wbaker7702/nemo/security/code-scanning/26)

To fix the problem, you should add a `permissions` block to the workflow or the specific job. Since the workflow only needs to read repository contents (for actions like checking out code and installing dependencies), the minimal required permission is `contents: read`. This can be set at the job level (inside the `tests` job) or at the workflow root (to apply to all jobs). In this case, since only one job is present, either location is acceptable, but adding it at the job level is most precise. You should insert the following block under the job definition (after `name: Tests` and before `runs-on: ubuntu-latest`):

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
