### PR TITLE
Potential fix for code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/app/assets/javascripts/legacy/views/report/table_display.js
+++ b/app/assets/javascripts/legacy/views/report/table_display.js
@@ -60,7 +60,7 @@
       // rest of header cells
       if (headers.col) {
         $(headers.col.cells).each((idx, ch) => {
-          $('<th>').addClass('col').html(ch.name || `[${I18n.t('report/report.blank')}]`).appendTo(trow);
+          $('<th>').addClass('col').text(ch.name || `[${I18n.t('report/report.blank')}]`).appendTo(trow);
         });
       }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/12](https://github.com/Wbaker7702/nemo/security/code-scanning/12)

To fix this issue, we should avoid inserting untrusted data as HTML. Instead of using `.html()`, which interprets its argument as HTML, we should use `.text()`, which safely inserts the content as plain text, escaping any HTML meta-characters. This change should be made on line 63, replacing `.html(ch.name || ...)` with `.text(ch.name || ...)`. This ensures that any special characters in `ch.name` are properly escaped, preventing XSS vulnerabilities, while preserving the intended display of the value.

No additional imports or methods are needed, as `.text()` is a standard jQuery method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
