### PR TITLE
Potential fix for code scanning alert no. 29: Dependency download using unencrypted communication channel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem "rails", "~> 7.1.0"
 


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/29](https://github.com/Wbaker7702/nemo/security/code-scanning/29)

The best way to fix this problem is to change the unencrypted HTTP URL to its encrypted HTTPS equivalent. Specifically, in the `Gemfile`, the line:

```ruby
source "http://rubygems.org"
```

should be replaced with:

```ruby
source "https://rubygems.org"
```

This change ensures that all gem downloads are performed over an encrypted channel, protecting against MITM attacks, and is the recommended and supported configuration for Ruby gems. Only this single line in the Gemfile needs to be changed, and no additional imports or method changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
