### PR TITLE
Potential fix for code scanning alert no. 2: Useless regular-expression character escape

### DIFF
--- a/vendor/assets/javascripts/trumbowyg/trumbowyg.js
+++ b/vendor/assets/javascripts/trumbowyg/trumbowyg.js
@@ -231,7 +231,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                 var scriptElements = document.getElementsByTagName('script');
                 for (var i = 0; i < scriptElements.length; i += 1) {
                     var source = scriptElements[i].src;
-                    var matches = source.match('trumbowyg(\.min)?\.js');
+                    var matches = source.match('trumbowyg(\\.min)?\\.js');
                     if (matches != null) {
                         svgPathOption = source.substring(0, source.indexOf(matches[0])) + 'ui/icons.svg';
                     }


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/2](https://github.com/Wbaker7702/nemo/security/code-scanning/2)

To fix the problem, we need to ensure that the string used as the regex pattern for matching script source URLs is properly escaped to represent literal dot characters. In JavaScript string literals, to match a literal dot in a RegExp created from a string, you must use a double backslash: `'\\.'`, so that the RegExp sees `\.`. Therefore, in the string `'trumbowyg(\.min)?\.js'`, all single backslashes before dots must be doubled to `'trumbowyg(\\.min)?\\.js'`.

Concretely, in `vendor/assets/javascripts/trumbowyg/trumbowyg.js`, on line 234, update:
```javascript
var matches = source.match('trumbowyg(\.min)?\.js');
```
to:
```javascript
var matches = source.match('trumbowyg(\\.min)?\\.js');
```
No imports or further code changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
