### PR TITLE
Potential fix for code scanning alert no. 15: DOM text reinterpreted as HTML

### DIFF
--- a/vendor/assets/javascripts/trumbowyg/trumbowyg.js
+++ b/vendor/assets/javascripts/trumbowyg/trumbowyg.js
@@ -9,6 +9,7 @@
  *         Website : alex-d.fr
  */
 
+// Assumes DOMPurify is loaded and available globally as window.DOMPurify, or adapt import as necessary.
 jQuery.trumbowyg = {
     langs: {
         en: {
@@ -1093,7 +1094,8 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                 //scrub the html before loading into the doc
                 var safe = $('<div>').append(html);
                 $(t.o.tagsToRemove.join(','), safe).remove();
-                t.$ed.html(safe.contents().html());
+                var sanitized = DOMPurify.sanitize(safe.contents().html());
+                t.$ed.html(sanitized);
             }
 
             if (t.o.autogrow) {


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/15](https://github.com/Wbaker7702/nemo/security/code-scanning/15)

To fix this issue, you should ensure that any text extracted from the DOM and re-inserted as HTML is properly sanitized first. Simply removing some tags is not enough; you need to use a robust HTML sanitizer that removes or escapes all dangerous elements and attributes. The best approach (which can be implemented without altering core functionality) is to use an established, maintained sanitization library such as [DOMPurify](https://github.com/cure53/DOMPurify) to clean the HTML content. As you can only edit the `vendor/assets/javascripts/trumbowyg/trumbowyg.js` file, you should first add the import (`import DOMPurify from 'dompurify'` or, if `require`, whatever is idiomatic, or assume it is available as global `window.DOMPurify`) and then sanitize the value before setting it via `.html()`.  
The region to change is close to line 1092: wrap `t.$ta.val()` with the sanitizer as you construct the jQuery wrapper. You should also remove potential dangerous content before attempting to set it as `.html()` even after your tag removal logic; so the last step before setting `.html()` must be the sanitization.  
In summary:  
- Import or access a standard sanitizer (DOMPurify is industry standard).
- Change the assignment so that, after the existing tag removal, the contents are sanitized.
- Only then pass sanitized contents to `t.$ed.html(...)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
