### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: RSpec & JS Tests
+permissions:
+  contents: read
 on: [push]
 jobs:
   tests:


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/nemo/security/code-scanning/28](https://github.com/Wbaker7702/nemo/security/code-scanning/28)

**General fix:**  
Explicitly set the minimal required permissions for the workflow or job by adding a `permissions:` block. For most test workflows (which do not require GitHub API write actions), `permissions: contents: read` is recommended.

**Detailed fix:**  
Since this workflow is not interacting with the GitHub API in a way that requires write access (it's only checking out code, caching, installing, and running tests), the `contents: read` permission is sufficient and minimal. To fix, insert a `permissions:` block with `contents: read` at either the root of the workflow file (applies to all jobs), or under the `tests` job (local to that job only). Best practice is to set at the root unless some jobs require special permissions.

**Where to change:**  
Edit `.github/workflows/tests.yml`, adding

```yaml
permissions:
  contents: read
```

after the `name:` and before `on: [push]` (the start of the workflow block), or just after the `on:` block and before `jobs:`. Either placement is correct and canonical.

**What is needed:**  
No imports, definitions, or extra setup—just add the right YAML lines.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
